### PR TITLE
Setting jinja2 HTML loader with auto escape = true

### DIFF
--- a/Create_Email.py
+++ b/Create_Email.py
@@ -1,7 +1,7 @@
 from jinja2 import Environment, PackageLoader
 
 # Loads templates from the yourapp.templates folder
-env = Environment(loader=PackageLoader('emailer', 'templates'))
+env = Environment(loader=PackageLoader('emailer', 'templates'), autoescape=True)
 
 
 class CreateEmail(object):


### PR DESCRIPTION
This is being done to mitigate XSS vulnerability: 

B701: jinja2_autoescape_false
B701: Test for not auto escaping in jinja2
Jinja2 is a Python HTML templating system. It is typically used to build web applications, though appears in other places well, notably the Ansible automation system. When configuring the Jinja2 environment, the option to use autoescaping on input can be specified. When autoescaping is enabled, Jinja2 will filter input strings to escape any HTML content submitted via template variables. Without escaping HTML input the application becomes vulnerable to Cross Site Scripting (XSS) attacks.

Unfortunately, autoescaping is False by default. Thus this plugin test will warn on omission of an autoescape setting, as well as an explicit setting of false. A HIGH severity warning is generated in either of these scenarios.